### PR TITLE
Loosen up the opencensus dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
-{deps, [{opencensus, "~> 0.7.0"},
+{deps, [{opencensus, "~> 0.7"},
         {jsx, "~> 2.9"}]}.
 
 {project_plugins, [rebar3_lint,


### PR DESCRIPTION
Will allow for oc_datadog to work with opencensus_phoenix and others. Resolves #5