### PR TITLE
cast metadata field values that are ints or floats, to binary

### DIFF
--- a/src/oc_reporter_datadog.erl
+++ b/src/oc_reporter_datadog.erl
@@ -125,7 +125,11 @@ build_span(Span, Service, Type) ->
       <<"type">> => to_tag(Type),
       <<"meta">> => to_meta(Span#span.attributes)}.
 
-to_meta(Attributes) -> maps:map(fun to_tag/2, Attributes).
+to_meta(Attributes) -> maps:map(fun to_meta/2, Attributes).
+
+to_meta(_Name, Value) when is_integer(Value) -> integer_to_binary(Value);
+to_meta(_Name, Value) when is_float(Value) -> float_to_binary(Value, [compact, {decimals, 253}]);
+to_meta(Name, Value) -> to_tag(Name, Value).
 
 to_tag(Value) -> to_tag(nil, Value).
 

--- a/src/oc_reporter_datadog.erl
+++ b/src/oc_reporter_datadog.erl
@@ -128,7 +128,8 @@ build_span(Span, Service, Type) ->
 to_meta(Attributes) -> maps:map(fun to_meta/2, Attributes).
 
 to_meta(_Name, Value) when is_integer(Value) -> integer_to_binary(Value);
-to_meta(_Name, Value) when is_float(Value) -> float_to_binary(Value, [compact, {decimals, 253}]);
+to_meta(_Name, Value) when is_float(Value) ->
+    float_to_binary(Value, [compact, {decimals, 253}]);
 to_meta(Name, Value) -> to_tag(Name, Value).
 
 to_tag(Value) -> to_tag(nil, Value).

--- a/test/oc_reporter_datadog_SUITE.erl
+++ b/test/oc_reporter_datadog_SUITE.erl
@@ -16,7 +16,7 @@ init_per_testcase(_, Config) ->
               span_id = 1,
               start_time = wts:timestamp(),
               end_time = wts:timestamp(),
-              attributes = #{foo => "bar"}
+              attributes = #{foo => "bar", baz => 10, buz => 1.0}
              },
     Options = oc_reporter_datadog:init([{http_client, fun mock_client/3}]),
     [{span, Span}, {options, Options} | Config].
@@ -38,7 +38,7 @@ test_reports_spans(Config) ->
              <<"span_id">> := 1,
              <<"type">> := <<"custom">>,
              <<"duration">> := _,
-             <<"meta">> := #{<<"foo">> := <<"bar">>}} = RSpan,
+             <<"meta">> := #{<<"foo">> := <<"bar">>, <<"baz">> := <<"10">>, <<"buz">> := <<"1.0">>}} = RSpan,
             ok;
         Msg ->
             ct:fail("Unknown message: ~p", [Msg])


### PR DESCRIPTION
Addresses #8 

I used 253 because that is the highest precision we will be able to preserve in the conversion according to http://erlang.org/doc/man/erlang.html#float_to_binary-2

Looking forward to your feedback.